### PR TITLE
Bump golang to 1.22.3 and ignore `k8s.io/*` deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,23 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
     reviewers:
       - "ironcore-dev/core"
+    # Ignore K8 packages as these are done manually
+    ignore:
+      - dependency-name: "k8s.io/api"
+      - dependency-name: "k8s.io/apiextensions-apiserver"
+      - dependency-name: "k8s.io/apimachinery"
+      - dependency-name: "k8s.io/apiserver"
+      - dependency-name: "k8s.io/client-go"
+      - dependency-name: "k8s.io/component-base"
+      - dependency-name: "k8s.io/kube-aggregator"
+      - dependency-name: "k8s.io/kubectl"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
     reviewers:
       - "ironcore-dev/core"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
+          version: v1.58.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
 
 jobs:

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,7 +1,7 @@
 name: Size Label
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.28.0
+ENVTEST_K8S_VERSION = 1.29.0
 
 # 'sample' folder, where you mentioned the `go mod download` should take place
 SAMPLE_DIR = sample
@@ -83,8 +83,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.14.0
-GOLANGCI_LINT_VERSION ?= v1.55.2
+GOIMPORTS_VERSION ?= v0.21.0
+GOLANGCI_LINT_VERSION ?= v1.58.0
 
 .PHONY: addlicense
 addlicense: $(ADDLICENSE) ## Download addlicense locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/openapi-extractor
 
-go 1.21
+go 1.22.3
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/sample/go.mod
+++ b/sample/go.mod
@@ -1,5 +1,5 @@
 module github.com/ironcore-dev/openapi-extractor/sample
 
-go 1.21
+go 1.22.2
 
-require github.com/ironcore-dev/ironcore v0.1.2-0.20240115105645-09183cfa3d80
+require github.com/ironcore-dev/ironcore v0.1.2-0.20240419083055-c4ea6c886eda // indirect

--- a/sample/go.sum
+++ b/sample/go.sum
@@ -1,3 +1,2 @@
-github.com/ironcore-dev/ironcore v0.1.2-0.20240111223726-47afcd8e8d13/go.mod h1:Jd+EhBiQT/mR0WyFdZ4OfymFzX97Iw3Gqm7Yz4edYgQ=
-github.com/ironcore-dev/ironcore v0.1.2-0.20240115105645-09183cfa3d80 h1:d3U97hAU319EVamZhJ2nNKOgveqTy4BTLGilm8nZvMc=
-github.com/ironcore-dev/ironcore v0.1.2-0.20240115105645-09183cfa3d80/go.mod h1:cTjq3AobNNQg/U/bJwrk+JYrX5o0izrQygtIB14Riaw=
+github.com/ironcore-dev/ironcore v0.1.2-0.20240419083055-c4ea6c886eda h1:QeIM9YtLkVmNZ+95ae7FRlOczcYLTQg8YUswPvHPhuI=
+github.com/ironcore-dev/ironcore v0.1.2-0.20240419083055-c4ea6c886eda/go.mod h1:S9vJ69zFNoE0zBzWXeLlscMExfuJDXQrIoaYTGwE3mE=


### PR DESCRIPTION
# Proposed Changes

- Bump golang to 1.22.3
- Ignore `k8s.io/*` deps in dependabot configuration
- Bump golangci-lint and goimports