### PR TITLE
Bump `golangci-lint` to v2.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "ironcore-dev/core"
     # Ignore K8 packages as these are done manually
     ignore:
       - dependency-name: "k8s.io/api"
@@ -22,11 +20,7 @@ updates:
     directory: "/sample"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "ironcore-dev/core"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "ironcore-dev/core"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.4

--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.31.0
-GOLANGCI_LINT_VERSION ?= v2.1
+GOIMPORTS_VERSION ?= v0.36.0
+GOLANGCI_LINT_VERSION ?= v2.4
 
 .PHONY: addlicense
 addlicense: $(ADDLICENSE) ## Download addlicense locally if necessary.


### PR DESCRIPTION
# Proposed Changes

- Bump `golangci-lint` to v2.4
- Update dependabot configuration
- Bump `goimports` to v0.36.0

